### PR TITLE
Adjusted description meta tag content for blogs to improve SEO

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,14 @@
 
 	{{ template "_internal/google_analytics.html" . }}
 
-    {{ with .Site.Params.description }}<meta name="description" content="{{ . | plainify }}">{{ end }}
+    {{ $description := "" }}
+      {{ if .Description }}
+        {{ $description = .Description }}
+      {{ else }}
+        {{ $description = .Site.Params.description }}
+    {{ end }}
+    <meta name="description" content="{{ $description }}">
+
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
     {{ range .AlternativeOutputFormats -}}
       {{ printf `<link rel="%s" type="%s" href="%s" title="%s">` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}


### PR DESCRIPTION
Before:
- blog posts uses the description defined in config.toml

After:
- blog posts use descriptions that's defined in md files

Screenshot:
![image](https://github.com/xantaren/spectral/assets/68090976/9e2c8e73-737f-4fe5-b9e0-39de75be0676)
![image](https://github.com/xantaren/spectral/assets/68090976/6cc50eae-5031-4609-9379-671c26670f23)
